### PR TITLE
support new separators

### DIFF
--- a/lib/csv_schema/parser.ex
+++ b/lib/csv_schema/parser.ex
@@ -12,7 +12,9 @@ defmodule Csv.Schema.Parser do
   def csv!(stream, headers, separator = ?;), do: csv(stream, headers, separator)
   def csv!(stream, headers, separator = ?,), do: csv(stream, headers, separator)
   def csv!(stream, headers, separator = ?\t), do: csv(stream, headers, separator)
-  def csv!(_, _, s), do: raise("Separator '#{s}' should be a codepoint and one of ';' ',' or '\\t'")
+  def csv!(stream, headers, separator = ?\s), do: csv(stream, headers, separator)
+  def csv!(stream, headers, separator = ?|), do: csv(stream, headers, separator)
+  def csv!(_, _, s), do: raise("Separator '#{s}' should be a codepoint and one of ';' ',' '\\t' '\\s' '|'")
 
   @spec csv(%Stream{}, boolean, pos_integer) :: %Stream{} | no_return
   defp csv(stream, headers, separator) do


### PR DESCRIPTION
also space and pipe are often used separators
due to column content that contains ; or , or space as normal text